### PR TITLE
Save user cart items to database

### DIFF
--- a/frontend/src/component/authantication/isauthanticat.jsx
+++ b/frontend/src/component/authantication/isauthanticat.jsx
@@ -20,14 +20,7 @@ export async function Logout() {
   const token = localStorage.getItem("token");
   const userId = localStorage.getItem("userId");
 
-  // Clear server cart for this user if logged in
-  if (userId && token) {
-    try {
-      await axios.delete(`${BaseURL}/api/cart/clear/${userId}`, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
-    } catch (_) {}
-  }
+  // Do NOT clear server cart on logout; we want persistence across sessions
 
   // Clear client cart (IndexedDB + localStorage)
   try {


### PR DESCRIPTION
Persist cart items across user sessions by stopping server cart clearance on logout, normalizing cart item IDs, and migrating IndexedDB to use `_id` as the key.

After logout and login with the same email, cart items were not showing because the server-side cart was being cleared. This PR ensures that the cart items are saved in the database and displayed when the user logs in, by keeping the server cart intact and standardizing item identification across the frontend and local storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-120da3cf-a0b9-49fb-b424-b949fd97af7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-120da3cf-a0b9-49fb-b424-b949fd97af7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

